### PR TITLE
release "homemade signals" and add reference in first signal article

### DIFF
--- a/published/homemade-signals.md
+++ b/published/homemade-signals.md
@@ -6,7 +6,6 @@ tags: signals, web-development, javascript, frontend-development, reactivity, gu
 cover: https://cdn.hashnode.com/res/hashnode/image/upload/v1708269071670/uuXEcIHgR.jpg?auto=format
 publishAs: culas
 hideFromHashnodeCommunity: false
-saveAsDraft: true
 ---
 
 _First off: the code in this post is not meant to be used for production-level application but serves an educational purpose._

--- a/published/signals-everywhere.md
+++ b/published/signals-everywhere.md
@@ -160,4 +160,4 @@ How do you think will Signals influence the future of web development?
 Do you think React's long-running dominance will continue, or do you think they should start adding Signals?
 I'd love to hear your thoughts!
 
-_Stay tuned for a follow-up article, where we will build our own homemade Signal! It will give us a better understanding of why effects are so central._
+_Check out the follow-up article, where we build our own [homemade Signals](https://software-engineering-corner.zuehlke.com/homemade-signals)! It gives us a better understanding of why effects are so central._


### PR DESCRIPTION
Just a small change so that readers in the future will be shown towards the homemade signals article