### PR TITLE
Add search capability via astro-pagefind

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Astro powers the blog.
 You will need Node (or something similar, like Deno or Bun).
 
 1. Install Dependencies: `npm install`
-2. Run: `npm run dev`
-3. Go to http://localhost:4321
+2. *(optional)* To create a search index run: `npm run build`
+3. Run: `npm run dev`
+4. Go to http://localhost:4321
 
 ## Images
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,8 @@ import mdx from "@astrojs/mdx";
 
 import sitemap from "@astrojs/sitemap";
 
+import pagefind from "astro-pagefind";
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://thedevexchange.com',
@@ -18,7 +20,7 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
-  integrations: [react(), expressiveCode(), mdx(), sitemap()],
+  integrations: [react(), expressiveCode(), mdx(), sitemap(), pagefind()],
 
   trailingSlash: 'always',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tailwindcss/vite": "^4.1.8",
         "astro": "^5.7.13",
         "astro-expressive-code": "^0.41.2",
+        "astro-pagefind": "^1.8.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.8"
@@ -1403,6 +1404,96 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.4.0.tgz",
+      "integrity": "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -1995,6 +2086,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.10",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.8.tgz",
@@ -2491,6 +2636,20 @@
       },
       "peerDependencies": {
         "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
+      }
+    },
+    "node_modules/astro-pagefind": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-1.8.5.tgz",
+      "integrity": "sha512-CVhKKA9bTQ7hLsHk9KTNDzOdgR4EI04gn0mjDGfnXzaHx7rL92YkNpFM5AoFl9NWmOUbaIFC2DN7Yvs/ZFPRdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/default-ui": "^1.2.0",
+        "pagefind": "^1.2.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/axobject-query": {
@@ -5573,6 +5732,23 @@
       "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
       "license": "MIT"
     },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
+      }
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -6285,6 +6461,20 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6496,6 +6686,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tailwindcss/vite": "^4.1.8",
     "astro": "^5.7.13",
     "astro-expressive-code": "^0.41.2",
+    "astro-pagefind": "^1.8.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^4.1.8"

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import ThemeToggle from './ThemeToggle';
+import SearchModal from './SearchModal.astro';
 ---
 <style is:inline>
     ::view-transition-group(header) {
@@ -13,6 +14,16 @@ import ThemeToggle from './ThemeToggle';
     <div class="flex gap-4 justify-between px-0 text-sm items-center">
       <a href="https://www.zuehlke.com/en" target="_blank" class="hidden sm:block">ZÜHLKE</a>
       <a href="https://www.zuehlke.com/en/careers" target="_blank" class="hidden sm:block">CAREERS</a>
+      <button id="search-button"
+              class="focus:outline-2 focus:outline-offset-2 focus:outline-slate-800 dark:focus:outline-slate-200 cursor-pointer"
+              aria-label="Open search">
+        <svg fill="none" height="30" stroke="currentColor" stroke-linecap="round"
+             stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="30"
+             xmlns="http://www.w3.org/2000/svg">
+          <circle cx="11" cy="11" r="8"/>
+          <path d="m21 21-4.35-4.35"/>
+        </svg>
+      </button>
       <a href="/rss.xml"
          class="focus:outline-2 focus:outline-offset-2 focus:outline-slate-800 dark:focus:outline-slate-200">
         <svg fill="none" height="30" stroke="currentColor" stroke-linecap="round"
@@ -27,3 +38,5 @@ import ThemeToggle from './ThemeToggle';
     </div>
   </nav>
 </header>
+
+<SearchModal />

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,46 +1,26 @@
 ---
-// SearchModal.astro - Dedicated search modal component
+import Search from "astro-pagefind/components/Search";
 ---
 
-<!-- Search Modal -->
 <div id="search-modal" class="fixed inset-0 z-50 hidden">
-  <!-- Backdrop with blur -->
   <div id="search-backdrop" class="absolute inset-0 bg-zag-dark/20 dark:bg-zag-light/20 backdrop-blur-sm"></div>
   
-  <!-- Modal content -->
   <div class="relative z-10 flex items-start justify-center min-h-screen px-4 pt-16 sm:pt-24">
     <div class="w-full max-w-2xl">
-      <!-- Search input container -->
       <div class="modal-content bg-zag-light dark:bg-zag-dark zag-transition border-2 border-zag-dark dark:border-zag-light shadow-xl">
-        <div class="p-4">
-          <div class="relative">
-            <input
-              type="text"
-              id="search-input"
-              placeholder="Search articles..."
-              class="w-full px-4 py-3 text-lg bg-transparent border-none outline-none text-zag-dark dark:text-zag-light placeholder-zag-dark-muted dark:placeholder-zag-light-muted zag-transition font-sans"
-              autocomplete="off"
-              autocorrect="off"
-              autocapitalize="off"
-              spellcheck="false"
-            />
-            <button
-              id="search-close"
-              class="absolute right-2 top-1/2 transform -translate-y-1/2 p-2 hover:bg-zag-dark-muted/10 dark:hover:bg-zag-light-muted/10 zag-transition"
-              aria-label="Close search"
-            >
-              <svg width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24">
-                <path d="M18 6L6 18M6 6l12 12"/>
-              </svg>
-            </button>
-          </div>
-        </div>
-        
-        <!-- Search results placeholder -->
-        <div id="search-results" class="border-t-2 border-zag-dark dark:border-zag-light max-h-96 overflow-y-auto">
-          <div class="p-4 text-center text-zag-dark-muted dark:text-zag-light-muted">
-            Start typing to search articles...
-          </div>
+        <div class="relative">
+          <button
+            id="search-close"
+            class="absolute right-4 top-2 z-10 p-2 cursor-pointer hover:bg-zag-dark-muted/10 dark:hover:bg-zag-light-muted/10 zag-transition"
+            aria-label="Close search"
+          >
+            <svg width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24">
+              <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+          </button>
+          
+          <!-- astro-pagefind Search component -->
+          <Search id="search" className="pagefind-ui" uiOptions={{ showImages: false }} />
         </div>
       </div>
     </div>
@@ -80,46 +60,98 @@
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
   }
-  
-  /* Focus styles for search input */
-  #search-input:focus {
-    outline: none;
-  }
-  
-  /* Dark mode focus styles */
-  .dark #search-input:focus {
-    outline: none;
-  }
 </style>
+<style is:global>
+  /* Overrides of the astro-pagefind component styles */
+  :root {
+   --pagefind-ui-scale: 0.8;
+   --pagefind-ui-primary: var(--color-zag-dark);
+   --pagefind-ui-text: var(--color-zag-dark);
+   --pagefind-ui-message-text: var(--color-zag-dark);
+   --pagefind-ui-result-title-text: var(--brand);
+   --pagefind-ui-result-text: var(--color-zag-dark);
+   --pagefind-ui-background: var(--color-zag-light);
+   --pagefind-input-background: var(--color-zag-light);
+   --pagefind-ui-tag: var(--color-zag-dark-muted);
+   --pagefind-ui-border: var(--color-zag-accent-light);
+   --pagefind-ui-border-width: 0;
+   --pagefind-ui-border-radius: 0;
+   --pagefind-ui-image-border-radius: 4px;
+   --pagefind-ui-image-box-ratio: 3 / 2;
+   --pagefind-ui-font: var(--font-sans);
+   --pagefind-button-background: var(--color-zag-light);
+   --pagefind-button-color: var(--color-zag-dark);
+    &:where(.dark, .dark *) {
+      --pagefind-ui-primary: var(--color-zag-light);
+      --pagefind-ui-text: var(--color-zag-light);
+      --pagefind-ui-message-text: var(--pagefind-ui-text);
+      --pagefind-ui-result-title-text: var(--color-zag-accent-dark);
+      --pagefind-ui-result-text: var(--color-zag-light);
+      --pagefind-ui-background: var(--color-zag-dark);
+      --pagefind-input-background: var(--color-zag-light);
+      --pagefind-ui-border: var(--color-zag-light);
+      --pagefind-ui-tag: var(--color-zag-light-muted);
+    }
+  }
 
-<script>
-  // Search modal functionality that works with Astro page transitions
+  #search .pagefind-ui__drawer {
+    padding: 0 10px;
+    max-height: 66vh;
+    overflow-y: scroll;
+    scrollbar-color: var(--color-zag-dark);
+
+    &:where(.dark, .dark *) {
+      scrollbar-color: var(--color-zag-light);
+    }
+  }
+
+  #search .pagefind-ui__search-clear {
+    visibility: hidden;
+  }
+
+  #search .pagefind-ui__search-input {
+    outline: none;
+    border-bottom: var(--zag-stroke) solid;
+    border-color: var(--color-zag-dark);
+    
+    &:where(.dark, .dark *) {
+      border-color: var(--color-zag-light);
+    }
+  }
+
+  #search .pagefind-ui__button {
+    border-top: 2px solid var(--color-zag-dark-muted);
+    margin: 5px 0;
+
+    &:where(.dark, .dark *) {
+      border-top: 2px solid var(--color-zag-light-muted);
+    }
+  }
+</style><script>
   function initSearchModal() {
     const searchButton = document.getElementById('search-button');
     const searchModal = document.getElementById('search-modal');
     const searchBackdrop = document.getElementById('search-backdrop');
     const searchClose = document.getElementById('search-close');
-    const searchInput = document.getElementById('search-input') as HTMLInputElement;
 
     function openModal() {
       searchModal?.classList.remove('hidden');
       document.body.style.overflow = 'hidden';
-      // Focus the input after a brief delay to ensure modal is visible
-      setTimeout(() => {
-        searchInput?.focus();
-      }, 100);
+      const searchInput = searchModal?.querySelector('.pagefind-ui__search-input') as HTMLInputElement;
+      searchInput?.focus();
     }
 
     function closeModal() {
       searchModal?.classList.add('hidden');
       document.body.style.overflow = '';
-      // Clear the search input
+
+      const searchInput = searchModal?.querySelector('.pagefind-ui__search-input') as HTMLInputElement;
       if (searchInput) {
         searchInput.value = '';
+        searchInput.dispatchEvent(new Event('input', { bubbles: true }));
       }
     }
 
-    // Remove any existing event listeners to prevent duplicates
     const newSearchButton = searchButton?.cloneNode(true) as HTMLElement;
     const newSearchClose = searchClose?.cloneNode(true) as HTMLElement;
     const newSearchBackdrop = searchBackdrop?.cloneNode(true) as HTMLElement;
@@ -139,31 +171,23 @@
       newSearchBackdrop.addEventListener('click', closeModal);
     }
 
-    // Also add click handler to the modal container itself for better UX
     const modalContainer = searchModal?.querySelector('.flex.items-start.justify-center');
     modalContainer?.addEventListener('click', closeModal);
 
-    // Close modal when Escape key is pressed
     function handleKeydown(event: KeyboardEvent) {
       if (event.key === 'Escape' && !searchModal?.classList.contains('hidden')) {
         closeModal();
       }
     }
 
-    // Remove existing keydown listener and add new one
     document.removeEventListener('keydown', handleKeydown);
     document.addEventListener('keydown', handleKeydown);
 
-    // Prevent closing when clicking inside the modal content box
     const modalContentBox = searchModal?.querySelector('.modal-content');
     modalContentBox?.addEventListener('click', function(event) {
       event.stopPropagation();
     });
   }
 
-  // Initialize on DOM content loaded
-  document.addEventListener('DOMContentLoaded', initSearchModal);
-  
-  // Re-initialize after Astro page transitions
   document.addEventListener('astro:page-load', initSearchModal);
 </script>

--- a/src/components/SearchModal.astro
+++ b/src/components/SearchModal.astro
@@ -1,0 +1,169 @@
+---
+// SearchModal.astro - Dedicated search modal component
+---
+
+<!-- Search Modal -->
+<div id="search-modal" class="fixed inset-0 z-50 hidden">
+  <!-- Backdrop with blur -->
+  <div id="search-backdrop" class="absolute inset-0 bg-zag-dark/20 dark:bg-zag-light/20 backdrop-blur-sm"></div>
+  
+  <!-- Modal content -->
+  <div class="relative z-10 flex items-start justify-center min-h-screen px-4 pt-16 sm:pt-24">
+    <div class="w-full max-w-2xl">
+      <!-- Search input container -->
+      <div class="modal-content bg-zag-light dark:bg-zag-dark zag-transition border-2 border-zag-dark dark:border-zag-light shadow-xl">
+        <div class="p-4">
+          <div class="relative">
+            <input
+              type="text"
+              id="search-input"
+              placeholder="Search articles..."
+              class="w-full px-4 py-3 text-lg bg-transparent border-none outline-none text-zag-dark dark:text-zag-light placeholder-zag-dark-muted dark:placeholder-zag-light-muted zag-transition font-sans"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              spellcheck="false"
+            />
+            <button
+              id="search-close"
+              class="absolute right-2 top-1/2 transform -translate-y-1/2 p-2 hover:bg-zag-dark-muted/10 dark:hover:bg-zag-light-muted/10 zag-transition"
+              aria-label="Close search"
+            >
+              <svg width="20" height="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+        
+        <!-- Search results placeholder -->
+        <div id="search-results" class="border-t-2 border-zag-dark dark:border-zag-light max-h-96 overflow-y-auto">
+          <div class="p-4 text-center text-zag-dark-muted dark:text-zag-light-muted">
+            Start typing to search articles...
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Search modal animations */
+  #search-modal {
+    animation: fadeIn 0.2s ease-out;
+  }
+  
+  #search-modal.hidden {
+    animation: fadeOut 0.2s ease-out;
+  }
+  
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  
+  @keyframes fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+  
+  /* Ensure proper backdrop blur support */
+  .backdrop-blur-sm {
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+  }
+  
+  /* Focus styles for search input */
+  #search-input:focus {
+    outline: none;
+  }
+  
+  /* Dark mode focus styles */
+  .dark #search-input:focus {
+    outline: none;
+  }
+</style>
+
+<script>
+  // Search modal functionality that works with Astro page transitions
+  function initSearchModal() {
+    const searchButton = document.getElementById('search-button');
+    const searchModal = document.getElementById('search-modal');
+    const searchBackdrop = document.getElementById('search-backdrop');
+    const searchClose = document.getElementById('search-close');
+    const searchInput = document.getElementById('search-input') as HTMLInputElement;
+
+    function openModal() {
+      searchModal?.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+      // Focus the input after a brief delay to ensure modal is visible
+      setTimeout(() => {
+        searchInput?.focus();
+      }, 100);
+    }
+
+    function closeModal() {
+      searchModal?.classList.add('hidden');
+      document.body.style.overflow = '';
+      // Clear the search input
+      if (searchInput) {
+        searchInput.value = '';
+      }
+    }
+
+    // Remove any existing event listeners to prevent duplicates
+    const newSearchButton = searchButton?.cloneNode(true) as HTMLElement;
+    const newSearchClose = searchClose?.cloneNode(true) as HTMLElement;
+    const newSearchBackdrop = searchBackdrop?.cloneNode(true) as HTMLElement;
+    
+    if (searchButton && newSearchButton) {
+      searchButton.parentNode?.replaceChild(newSearchButton, searchButton);
+      newSearchButton.addEventListener('click', openModal);
+    }
+    
+    if (searchClose && newSearchClose) {
+      searchClose.parentNode?.replaceChild(newSearchClose, searchClose);
+      newSearchClose.addEventListener('click', closeModal);
+    }
+    
+    if (searchBackdrop && newSearchBackdrop) {
+      searchBackdrop.parentNode?.replaceChild(newSearchBackdrop, searchBackdrop);
+      newSearchBackdrop.addEventListener('click', closeModal);
+    }
+
+    // Also add click handler to the modal container itself for better UX
+    const modalContainer = searchModal?.querySelector('.flex.items-start.justify-center');
+    modalContainer?.addEventListener('click', closeModal);
+
+    // Close modal when Escape key is pressed
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && !searchModal?.classList.contains('hidden')) {
+        closeModal();
+      }
+    }
+
+    // Remove existing keydown listener and add new one
+    document.removeEventListener('keydown', handleKeydown);
+    document.addEventListener('keydown', handleKeydown);
+
+    // Prevent closing when clicking inside the modal content box
+    const modalContentBox = searchModal?.querySelector('.modal-content');
+    modalContentBox?.addEventListener('click', function(event) {
+      event.stopPropagation();
+    });
+  }
+
+  // Initialize on DOM content loaded
+  document.addEventListener('DOMContentLoaded', initSearchModal);
+  
+  // Re-initialize after Astro page transitions
+  document.addEventListener('astro:page-load', initSearchModal);
+</script>

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -50,7 +50,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
             </div>
         </Header>
     </Fragment>
-    <section class="pt-8 max-w-4xl mx-auto px-8 mb-24">
+    <section class="pt-8 max-w-4xl mx-auto px-8 mb-24" data-pagefind-body>
         <div class="relative overflow-hidden hidden sm:block">
             <Image src={cover} alt="Cover image" class="aspect-video object-cover w-full"
                    width="800"
@@ -63,7 +63,8 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
             </h1>
         </div>
         <h1 class="text-2xl block sm:hidden leading-normal font-bold scroll-m-24 dark:text-zag-light text-zag-dark mb-3"
-            id="_top">
+            id="_top"
+            data-pagefind-meta="title">
             {title}
         </h1>
 


### PR DESCRIPTION
This PR adds search functionality to The Dev Exchange blog by using [pagefind](https://pagefind.app/) through [astro-pagefind](https://github.com/shishkin/astro-pagefind/).

A new icon is added to the navigation bar:

<img width="875" height="299" alt="image" src="https://github.com/user-attachments/assets/2bc1e855-3409-457d-bdc4-dfbb32ecae3d" />

Which opens a modal with a search input field and blurs the background:

<img width="875" height="1025" alt="image" src="https://github.com/user-attachments/assets/94f2bd46-52a5-4e4c-89d5-3a90ccf82efb" />

This PR really just restyles the `<Search />` component provided by astro-pagefind to match the look and feel of the blog.

pagefind works by indexing the blog posts at build time, thus there's no dynamic backend component required. It offers a bunch of options like filters for authors or tags, which could be considered at a later point.